### PR TITLE
Fix hidden code chunk

### DIFF
--- a/source/rs/_R/4-unsupclassification.rmd
+++ b/source/rs/_R/4-unsupclassification.rmd
@@ -26,7 +26,7 @@ Learn more about K-means and other unsupervised-supervised algorithms [here](htt
 
 We will perform unsupervised classification on a spatial subset of the `ndvi` layer.
 
-```{r echo = FALSE}
+```{r}
 ndvi <- (landsat5[['NIR']]-landsat5[['red']])/(landsat5[['NIR']]+landsat5[['red']])
 ```
 


### PR DESCRIPTION
# Update
When I went to make a pull request I saw that `ndvi` is defined in the  text, but the code chunk has `echo=FALSE` set, which is the cause of confusion.

# Issue
Section 4.1 - k-means classification has the following code - 
```
library
(raster)
landsat5 <- stack('data/rs/centralvalley-2011LT5.tif')
names(landsat5) <-c('blue', 'green', 'red', 'NIR', 'SWIR1', 'SWIR2')

# Extent to crop ndvi layer
e <- extent(-121.807, -121.725, 38.004, 38.072)
# crop landsat by the extent
ndvi <- crop(ndvi, e)
ndvi
## class       : RasterLayer
## dimensions  : 252, 304, 76608  (nrow, ncol, ncell)
## resolution  : 0.0002694946, 0.0002694946  (x, y)
## extent      : -121.807, -121.725, 38.00413, 38.07204  (xmin, xmax, ymin, ymax)
## coord. ref. : +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0
## data source : in memory
```

I expect `ndvi` here to be the same `ndvi` defined in Section 3: basic Mathematical Operations. However, when I execute the code, I get - 

```
 # k-means example
 library(raster)
 landsat5 <- stack('data/rs/centralvalley-2011LT5.tif')
 names(landsat5) <- c('blue', 'green', 'red', 'NIR', 'SWIR1', 'SWIR2')
 e <- extent(-121.807, -121.725, 38.004, 38.072)
 ndvi <- crop(ndvi, e)
Error in .local(x, y, ...) : extents do not overlap
```
If I replace `ndvi` with `raster5` as follows, this is the result -

```
UNSUPERVISED IMAGE CLASSIFICATION 
# k-means example 
library(raster) 
landsat5 <- stack('data/rs/centralvalley-2011LT5.tif')
 names(landsat5) <- c('blue', 'green', 'red', 'NIR', 'SWIR1', 'SWIR2') 
e <- extent(-121.807, -121.725, 38.004, 38.072) 
 landsat5 <- crop(landsat5, e) 
landsat5 class       : RasterBrick  dimensions  : 252, 304, 76608, 6  (nrow, ncol, ncell, nlayers) resolution  : 0.0002694946, 0.0002694946  (x, y) extent      : -121.807, -121.725, 38.00413, 38.07204  (xmin, xmax, ymin, ymax) coord. ref. : +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0  data source : in memory names       :        blue,       green,         red,         NIR,       SWIR1,       SWIR2  min values  : 0.084590562, 0.055765331, 0.040395390, 0.034050025, 0.010290771, 0.006807715  max values  :   0.3684652,   0.5407562,   0.5847761,   0.5988820,   0.5135725,   0.5523322   
nr <- getValues(landsat5)
str(nr) 
 num [1:76608, 1:6] 0.136 0.139 0.139 0.147 0.147 ...  - attr(*, "dimnames")=List of 2   ..$ : NULL   ..$ : chr [1:6] "blue" "green" "red" "NIR" ...
``` 
So now I get no error, and `nr` values are the same as the text in the book - 

```
str(nr)
##  num [1:76608] 0.245 0.236 0.272 0.277 0.277 ...
```

So suggest that we change those variables as in the pull request.